### PR TITLE
allow filtering data from db via hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ This is typically suitable for CI/CD deployed live environments.
 ### Including policies, roles and permissions
 Usually, a project has carefully configured levels of access that go along with your data model setup. This extension uses the term "rights" to collectively describe permissions, policies and roles along with their relations.
 
-**Note:** In order to prevent duplicates, avoid renaming and changing the description of the default roles and policies that come with the Directus initial setup.
+#### Things to note:
+- In order to prevent duplicates, avoid renaming and changing the description of the default roles and policies that come with the Directus initial setup.
+- Direct references to user IDs will be removed, since users are not synced.
+- Any relations that are exclusively between a user and policy will not be included at all.
 
 To enable separate sync files for rights, simple set the following env variable:
 ```
@@ -58,6 +61,25 @@ AUTOSYNC_INCLUDE_RIGHTS=true
 ```
 
 Now your rights data will be synced as well, stored in a separate file `rights.json`.
+
+### Custom filtering
+This extension features custom hooks, which gives you the option to customize exactly what's written to the sync files.
+Available filter hooks:
+- `simple-autosync.snapshot.pull`
+- `simple-autosync.policies.pull`
+- `simple-autosync.permissions.pull`
+- `simple-autosync.roles.pull`
+- `simple-autosync.access.pull`
+
+For [security reasons](https://github.com/directus/directus/discussions/10400#discussioncomment-1983100), Directus won't let you use the core event listener to listen for custom events like these. Example of how to configure a hook extension to listen:
+```
+export default (_, { emitter }) => {
+    // Exclude any policies with names starting with "User only"
+	emitter.onFilter("simple-autosync.policies.pull", (data) => {
+		return data.filter(policy => !policy.name.startsWith("User only"));
+	});
+};
+```
 
 ## What about my existing data model?
 **NOTE:** Using this extension will cause loss of data and unexpected problems if your environment that you are *applying the snapshot file to* already has collections (and roles, polices and permissions if using the rights feature) that are not represented in your snapshot file.

--- a/src/endpoints/index.js
+++ b/src/endpoints/index.js
@@ -109,6 +109,7 @@ export default defineEndpoint({
                     const pullRes = await pullSyncFiles(
                         context.services,
                         req.schema,
+                        context.emitter,
                         req.accountability,
                         await getVersion(req)
                     );
@@ -152,6 +153,7 @@ export default defineEndpoint({
                     diff = await pushSnapshot(
                         context.services,
                         req.schema,
+                        context.emitter,
                         req.accountability,
                         dryRun,
                         version
@@ -195,6 +197,7 @@ export default defineEndpoint({
                     const pushRightsRes = await pushRights(
                         context.services,
                         req.schema,
+                        context.emitter,
                         req.accountability,
                         dryRun,
                         version
@@ -249,7 +252,8 @@ export default defineEndpoint({
                         policiesService,
                         permissionsService,
                         rolesService,
-                        accessService
+                        accessService,
+                        context.emitter
                     );
                     r.rights = rights;
                     success = true;

--- a/src/hooks/auto.js
+++ b/src/hooks/auto.js
@@ -4,7 +4,7 @@ import * as snapshot from "../lib/snapshot";
 import * as rights from "../lib/rights";
 
 export default defineHook(
-    async ({ init, action }, { services, getSchema, logger }) => {
+    async ({ init, action }, { services, getSchema, logger, emitter }) => {
         const { SchemaService, ServerService } = services;
 
         // Fake admin since this is an internal process
@@ -75,6 +75,7 @@ export default defineHook(
                 await snapshot.pushSnapshot(
                     services,
                     schema,
+                    emitter,
                     accountability,
                     false,
                     versionData.version
@@ -83,6 +84,7 @@ export default defineHook(
                     await rights.pushRights(
                         services,
                         schema,
+                        emitter,
                         accountability,
                         false,
                         versionData.version
@@ -98,6 +100,7 @@ export default defineHook(
                 await snapshot.pullSyncFiles(
                     services,
                     schema,
+                    emitter,
                     accountability,
                     versionData.version
                 );

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -57,6 +57,7 @@ export function getEnvConfig() {
     const defaultAutosyncFilepath = `${process.cwd()}/autosync-config`;
     const autosyncFilepath =
         process.env.AUTOSYNC_FILE_PATH || defaultAutosyncFilepath;
+
     return {
         AUTOSYNC_PULL: isStringTruthy(process.env.AUTOSYNC_PULL),
         AUTOSYNC_PUSH: isStringTruthy(process.env.AUTOSYNC_PUSH),
@@ -80,3 +81,6 @@ export function readJson(filePath) {
 
 // log prefix
 export const LP = "simple-autosync:";
+
+// Hook prefix
+export const HP = "simple-autosync";

--- a/src/lib/rights.js
+++ b/src/lib/rights.js
@@ -6,6 +6,7 @@ import pick from "lodash/pick";
 import {
     getEnvConfig,
     getSyncFilePath,
+    HP,
     readJson,
     writeJson,
 } from "./helpers.js";
@@ -13,6 +14,7 @@ import {
 export async function pullRights(
     services,
     schema,
+    emitter,
     accountability,
     version,
     currentTimeStamp
@@ -31,7 +33,8 @@ export async function pullRights(
         policiesService,
         permissionsService,
         rolesService,
-        accessService
+        accessService,
+        emitter
     );
 
     const rightsFilePath = getSyncFilePath("rights", version, currentTimeStamp);
@@ -43,6 +46,7 @@ export async function pullRights(
 export async function pushRights(
     services,
     schema,
+    emitter,
     accountability,
     dryRun = false,
     version
@@ -78,7 +82,8 @@ export async function pushRights(
         policiesService,
         permissionsService,
         rolesService,
-        accessService
+        accessService,
+        emitter
     );
 
     // Figure out what roles/policies are default
@@ -361,34 +366,60 @@ export async function getCurrentRightsSetup(
     policiesService,
     permissionsService,
     rolesService,
-    accessService
+    accessService,
+    emitter
 ) {
+    const envConfig = getEnvConfig();
     const policies = await policiesService.readByQuery({
         limit: -1,
     });
+    let filteredPolicies = policies.map((policy) =>
+        omit(policy, ["roles", "permissions", "users"])
+    );
+    filteredPolicies = await emitter.emitFilter(`${HP}.policies.pull`, filteredPolicies);
+
     const permissions = await permissionsService.readByQuery({
         limit: -1,
     });
+    let filteredPermissions = permissions.filter(perm => {
+        const policy = filteredPolicies.find(policy => policy.id === perm.policy);
+        return !!policy && !perm.system;
+    })
+    filteredPermissions = await emitter.emitFilter(`${HP}.permissions.pull`, filteredPermissions);
+
     const roles = await rolesService.readByQuery({
         limit: -1,
     });
+    let filteredRoles = roles.map((role) =>
+        omit(role, ["policies", "users"])
+    );
+    filteredRoles = await emitter.emitFilter(`${HP}.roles.pull`, filteredRoles);
+
+
     const access = await accessService.readByQuery({
         limit: -1,
     });
+    let filteredAccess = access.filter(a => {
+        // If this is an access object that's only
+        // a relation between a policy and a local
+        // user, don't include it at all
+        const isPolicyUserRelation = a.user && a.policy && !a.role;
+        return !isPolicyUserRelation;
+    }).map(a => {
+        // Access has optional 'user' reference
+        return { ...a, user: null }
+    });
+    filteredAccess = await emitter.emitFilter(`${HP}.access.pull`, filteredAccess);
 
     // Clear away any relation info which we'll
     // re-create with access table below.
     // All references to users will be scrapped
     // since users don't carry over between envs.
     return {
-        policies: cleanUserRelations(policies).map((policy) =>
-            omit(policy, ["roles", "permissions"])
-        ),
-        permissions: permissions.filter((perm) => !perm.system),
-        roles: cleanUserRelations(roles).map((role) =>
-            omit(role, ["policies"])
-        ),
-        access: cleanUserRelations(access),
+        policies: filteredPolicies,
+        permissions: filteredPermissions,
+        roles: filteredRoles,
+        access: filteredAccess,
     };
 }
 
@@ -480,17 +511,6 @@ function rewriteDefaultsToPlaceholderIds(currentRightsData) {
     };
 }
 
-function cleanUserRelations(arr) {
-    return arr.map((o) => {
-        // Never include list of user IDs
-        const cleaned = omit(o, ["users"]);
-
-        // Access has optional 'user' reference
-        if (o.user) cleaned.user = null;
-
-        return cleaned;
-    });
-}
 
 function partitionCreateUpdate(fromFiles, fromCurrent) {
     // If an ID already exists in database,

--- a/src/lib/rights.js
+++ b/src/lib/rights.js
@@ -369,7 +369,6 @@ export async function getCurrentRightsSetup(
     accessService,
     emitter
 ) {
-    const envConfig = getEnvConfig();
     const policies = await policiesService.readByQuery({
         limit: -1,
     });


### PR DESCRIPTION
### Varför behövs detta? 

Tanken slog mig att detta kan vara användbart efter pratet om specifika behörigheter för specifika användare. Om man t ex skulle vilja jobba med policies som bara gäller utvalda användare och inte är kopplade till någon roll, kanske man inte heller vill inkludera dessa i en synk-fil mellan miljöer (eftersom användare inte synkas). Då kan man skapa en egen hook-extension som styr hur autosync funkar, så att man kan ignorera vissa policies, roller, eller kanske till och med vissa delar av datamodellen.